### PR TITLE
feat(dns): adds minimal working dns environment

### DIFF
--- a/ansible/ansible-ssh.cfg
+++ b/ansible/ansible-ssh.cfg
@@ -61,3 +61,27 @@ Host pxe
   Protocol 2
   User ansible
   LogLevel INFO
+
+Host dns
+  HostName dns.dev.oswee.com
+  StrictHostKeyChecking no
+  IdentitiesOnly yes
+  PreferredAuthentications publickey
+  IdentityFile ~/.ssh/ansible_dns_dev_ecdsa
+  CertificateFile ~/.ssh/ansible_dns_dev_ecdsa-cert.pub
+  Port 22
+  Protocol 2
+  User ansible
+  LogLevel INFO
+
+Host dns
+  HostName dns.prod.oswee.com
+  StrictHostKeyChecking no
+  IdentitiesOnly yes
+  PreferredAuthentications publickey
+  IdentityFile ~/.ssh/ansible_dns_prod_ecdsa
+  CertificateFile ~/.ssh/ansible_dns_prod_ecdsa-cert.pub
+  Port 22
+  Protocol 2
+  User ansible
+  LogLevel INFO

--- a/ansible/inventory/host_vars/dns/vars.yml
+++ b/ansible/inventory/host_vars/dns/vars.yml
@@ -3,4 +3,6 @@
 hostname: 'dns'
 host_octet: '251'
 ansible_python_interpreter: /usr/bin/python3.9
-mac: "7b:08:73:aa:e1:c5"
+mac: "56:90:01:22:e9:05"
+become_user: "ansible"
+dns_network_interface: "eth1"

--- a/ansible/roles/bind/handlers/main.yml
+++ b/ansible/roles/bind/handlers/main.yml
@@ -2,29 +2,34 @@
 # handlers file for roles/bind
 
 - name: enable named
-  systemd:
+  become: yes
+  ansible.builtin.systemd:
     name: named
     enabled: yes
 
 - name: start named
-  systemd:
+  become: yes
+  ansible.builtin.systemd:
     name: named
     state: started
 
 - name: restart named
-  systemd:
+  become: yes
+  ansible.builtin.systemd:
     state: restarted
     daemon_reload: yes
     name: named
 
 - name: restart firewalld
-  systemd:
+  become: yes
+  ansible.builtin.systemd:
     state: restarted
     daemon_reload: yes
     name: firewalld
 
 - name: restart NetworkManager
-  systemd:
+  become: yes
+  ansible.builtin.systemd:
     state: restarted
     daemon_reload: yes
     name: NetworkManager

--- a/ansible/roles/bind/meta/main.yml
+++ b/ansible/roles/bind/meta/main.yml
@@ -49,3 +49,5 @@ galaxy_info:
 
 dependencies:
 - name: dzintars.ansible.bind
+  vars:
+    network_interface_name: '{{ dns_network_interface }}'

--- a/ansible/roles/dhcpd/meta/main.yml
+++ b/ansible/roles/dhcpd/meta/main.yml
@@ -48,4 +48,4 @@ galaxy_info:
     #       maximum 20 tags per role.
 
 dependencies:
-- dzintars.ansible.dhcpd
+- name: dzintars.ansible.dhcpd

--- a/ansible/roles/minio/meta/main.yml
+++ b/ansible/roles/minio/meta/main.yml
@@ -49,7 +49,7 @@ galaxy_info:
     #       Maximum 20 tags per role.
 
 dependencies:
-  - name: dzintars.ansible.minio
-    vars:
-      minio_domain: "s3.oswee.com"
-      minio_server_port: "9000"
+- name: dzintars.ansible.minio
+  vars:
+    minio_domain: "s3.oswee.com"
+    minio_server_port: "9000"

--- a/terraform/environments/development/030dns/.terraform.lock.hcl
+++ b/terraform/environments/development/030dns/.terraform.lock.hcl
@@ -1,0 +1,118 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/dmacvicar/libvirt" {
+  version     = "0.6.3"
+  constraints = "~> 0.6.3"
+  hashes = [
+    "h1:oLSTCCmPIrIO88rNlIYnnWDn2EeHcM/Yie26kJpBqdM=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.1.0"
+  hashes = [
+    "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
+    "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
+    "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
+    "zh:719dfd97bb9ddce99f7d741260b8ece2682b363735c764cac83303f02386075a",
+    "zh:7598bb86e0378fd97eaa04638c1a4c75f960f62f69d3662e6d80ffa5a89847fe",
+    "zh:ad0a188b52517fec9eca393f1e2c9daea362b33ae2eb38a857b6b09949a727c1",
+    "zh:c46846c8df66a13fee6eff7dc5d528a7f868ae0dcf92d79deaac73cc297ed20c",
+    "zh:dc1a20a2eec12095d04bf6da5321f535351a594a636912361db20eb2a707ccc4",
+    "zh:e57ab4771a9d999401f6badd8b018558357d3cbdf3d33cc0c4f83e818ca8e94b",
+    "zh:ebdcde208072b4b0f8d305ebf2bfdc62c926e0717599dcf8ec2fd8c5845031c3",
+    "zh:ef34c52b68933bedd0868a13ccfd59ff1c820f299760b3c02e008dc95e2ece91",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.0"
+  hashes = [
+    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.1.0"
+  hashes = [
+    "h1:fUJX8Zxx38e2kBln+zWr1Tl41X+OuiE++REjrEyiOM4=",
+    "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
+    "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
+    "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",
+    "zh:95354df03710691773c8f50a32e31fca25f124b7f3d6078265fdf3c4e1384dca",
+    "zh:9f97ab190380430d57392303e3f36f4f7835c74ea83276baa98d6b9a997c3698",
+    "zh:a16f0bab665f8d933e95ca055b9c8d5707f1a0dd8c8ecca6c13091f40dc1e99d",
+    "zh:be274d5008c24dc0d6540c19e22dbb31ee6bfdd0b2cddd4d97f3cd8a8d657841",
+    "zh:d5faa9dce0a5fc9d26b2463cea5be35f8586ab75030e7fa4d4920cd73ee26989",
+    "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
+    "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
+    "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
+  ]
+}
+
+provider "registry.terraform.io/ivoronin/macaddress" {
+  version     = "0.2.2"
+  constraints = "~> 0.2.2"
+  hashes = [
+    "h1:lz0PXbk2JUjJ818n/eLgSN6UEvOYFhQ7cr35XL9VN4k=",
+    "zh:2a102920580920b9c7f97d922185ee5e08999d5c681016be22b56e4559323c54",
+    "zh:39b589f769770771521a661fb42c2ea1b234a71f78b65ba700b120f8f29ac3f4",
+    "zh:55aad84241749b499c7a68936ab10bd8aa99df627e223f8fedb533b3f4ecb52b",
+    "zh:675cf4c00c62f463bb1b0bb22d385f47e7111c9c46901013fa2e5441f237d6d7",
+    "zh:751ceccd42d29c81528cd68ac15000cb76a385f4b9c0d419d4fc620c56266077",
+    "zh:9ee227f579d1f71c5905142dae6fe49f3499ad8e719e77d4a96d6e4081883023",
+    "zh:c1195b474d635bb13519cb11b5146487d9280b1431eda69a65763d842f7c1e9f",
+    "zh:d068a860804280badcebb9ef7f165f603271694f3aea2bcb1d6d16e26455b83a",
+    "zh:e350de5379513816007428bc197e4860c64cb47414e530a1f6f8c4883663ec17",
+    "zh:e9f1a2c6d54dda5974013462b61c17da50aae1d0e6f28dd72d651e7b81bd4d7b",
+    "zh:f106b57628418a2f21a09d16c3c6e5a02cc619162879c997584543398742bf37",
+  ]
+}

--- a/terraform/environments/development/030dns/ansible.tf
+++ b/terraform/environments/development/030dns/ansible.tf
@@ -1,0 +1,30 @@
+resource "null_resource" "dns_config" {
+  # triggers = {
+  #   dhcp = module.dns
+  # }
+
+  provisioner "remote-exec" {
+    inline = ["echo Waiting for SSH..."]
+    connection {
+      host        = "dns"
+      type        = "ssh"
+      user        = "ansible"
+      private_key = tls_private_key.ansible.private_key_pem
+    }
+  }
+
+  # https://www.digitalocean.com/community/tutorials/how-to-use-ansible-with-terraform-for-configuration-management
+  provisioner "local-exec" {
+    working_dir = "../../../../ansible"
+    command = <<EOT
+      ansible-playbook playbooks/dns.yml
+    EOT
+  }
+
+  depends_on = [
+    local_file.ansible_ssh_priv_key,
+    module.dns,
+  ]
+}
+
+

--- a/terraform/environments/development/030dns/backend.tf
+++ b/terraform/environments/development/030dns/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = "./.state/terraform.tfstate"
+  }
+}

--- a/terraform/environments/development/030dns/data.tf
+++ b/terraform/environments/development/030dns/data.tf
@@ -1,0 +1,7 @@
+data "terraform_remote_state" "base" {
+  backend = "local"
+
+  config = {
+    path = "../000base/.state/terraform.tfstate"
+  }
+}

--- a/terraform/environments/development/030dns/main.tf
+++ b/terraform/environments/development/030dns/main.tf
@@ -1,0 +1,48 @@
+module "dns" {
+  # source = "git@github.com:dzintars/terraform-libvirt-domain.git?ref=v0.0.1-alpha"
+  source = "../../../../../../dzintars/terraform-libvirt-domain"
+
+  volume = {
+    name = "${var.instance_name}.${var.env_name}.${var.global_fqdn}"
+    pool = data.terraform_remote_state.base.outputs.libvirt_pool.name
+  }
+
+  cloudinit = {
+    name           = "${var.instance_name}.${var.env_name}.${var.global_fqdn}"
+    dhcp           = true
+    interface_name = "eth0"
+    addresses      = null
+    gateway        = null
+    nameservers    = {
+      ns1 = null
+      ns2 = null
+      ns3 = null
+    }
+  }
+
+  vm = {
+    user = "ansible"
+    user_ssh_pub_key = tls_private_key.ansible.public_key_openssh
+    hostname = "${var.instance_name}"
+    domain   = "${var.instance_name}.${var.env_name}.${var.global_fqdn}"
+  }
+
+  vault = {
+    address   = "https://vault.example.local"
+    role_id   = "role-id"
+    secret_id = "secret-id"
+  }
+
+  domain = {
+    name = "${var.instance_name}.${var.env_name}.${var.global_fqdn}"
+    memory = "1024"
+    vcpu   = "2"
+  }
+
+  network = {
+    name = data.terraform_remote_state.base.outputs.libvirt_network.name
+    mac  = "56:90:01:22:e9:05"
+    wait_for_lease = false
+  }
+}
+

--- a/terraform/environments/development/030dns/outputs.tf
+++ b/terraform/environments/development/030dns/outputs.tf
@@ -1,0 +1,27 @@
+# output "bastion_ip" {
+#   description = "The IP address of the Bastion Server"
+#   value       = module.bastion.instance_ip_addr
+# }
+
+# output "vault_ssh_client_public_key" {
+#   description = "SSH Client CA Public Key"
+#   value       = module.vault-ssh.client_ca_public_key
+# }
+
+# output "approle" {
+#   description = "Instance approle parameters"
+#   value = {
+#     id = module.vault-ssh.approle.id
+#     role = module.vault-ssh.approle.role
+#     secret = module.vault-ssh.approle.secret
+#   }
+# }
+
+# output "jenkins" {
+#   description = "Jenkins approle parameters"
+#   value = {
+#     id = module.vault-ssh.jenkins.id
+#     role = module.vault-ssh.jenkins.role
+#     secret = module.vault-ssh.jenkins.secret
+#   }
+# }

--- a/terraform/environments/development/030dns/provider.tf
+++ b/terraform/environments/development/030dns/provider.tf
@@ -1,0 +1,6 @@
+provider "libvirt" {
+  uri = "qemu:///system"
+  /* uri = "qemu+ssh://dzintars@192.168.1.2/system" */
+}
+
+

--- a/terraform/environments/development/030dns/ssh.tf
+++ b/terraform/environments/development/030dns/ssh.tf
@@ -1,0 +1,20 @@
+resource "tls_private_key" "ansible" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P521"
+}
+
+resource "local_file" "ansible_ssh_priv_key" {
+  content         = tls_private_key.ansible.private_key_pem
+  filename        = pathexpand("~/.ssh/${var.ansible_ssh_key_name}")
+  file_permission = "0600"
+
+  provisioner "local-exec" {
+    command = "ssh-add ${pathexpand("~/.ssh/${var.ansible_ssh_key_name}")}"
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+    # command = "ssh-keygen -R dns.${var.env_name}.${var.global_fqdn}"
+    command = "ssh-keygen -R dns.dev.oswee.com"
+  }
+}

--- a/terraform/environments/development/030dns/terraform.tfvars
+++ b/terraform/environments/development/030dns/terraform.tfvars
@@ -1,0 +1,4 @@
+env_name = "dev"
+env_layer = "030dns"
+global_fqdn = "oswee.com"
+instance_name = "dns"

--- a/terraform/environments/development/030dns/variables.tf
+++ b/terraform/environments/development/030dns/variables.tf
@@ -1,0 +1,24 @@
+variable "env_name" {
+  description = "Environment name"
+  type = string
+  default = "dev"
+}
+
+variable "global_fqdn" {
+  description = ""
+  type = string
+  default = "example.com"
+}
+
+variable "instance_name" {
+  description = ""
+  type = string
+  default = "dns"
+}
+
+variable "ansible_ssh_key_name" {
+  description = ""
+  type = string
+  default = "ansible_dns_dev_ecdsa"
+}
+

--- a/terraform/environments/development/030dns/versions.tf
+++ b/terraform/environments/development/030dns/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 0.14.7"
+  experiments = [module_variable_optional_attrs]
+
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "~>0.6.3"
+    }
+  }
+}
+


### PR DESCRIPTION
This is minimal working setup.
DNS records still need to be fixed.
Setup can be verified with `dig @192.168.67.251 master-0.dev.oswee.com` command. In the ANSWER SECTION it should return ip `192.168.67.10` which is the master-0 ip address.
Variable scopes should be cleaned and fixed as well.